### PR TITLE
clarify necessity of dots on arrow classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,14 +123,14 @@
 										<td>left_arrow_class</td>
 										<td>string</td>
 										<td><code>.glyphicon .glyphicon-chevron-left</code></td>
-										<td>The css classes to give to the left arrow</td>
+										<td>The css classes to give to the left arrow. You must prepend each class with "." or click handlers will stop working.</td>
 										<td></td>
 									</tr>
 									<tr>
 										<td>right_arrow_class</td>
 										<td>string</td>
 										<td><code>.glyphicon .glyphicon-chevron-right</code></td>
-										<td>The css classes to give to the right arrow</td>
+										<td>The css classes to give to the right arrow. You must prepend each class with "." or click handlers will stop working.</td>
 										<td></td>
 									</tr>
 									<tr>


### PR DESCRIPTION
This tripped me up and I don't seem to have been the only one: https://github.com/ashleydw/lightbox/issues/133

This clarifies that the preceding periods are necessary for event handlers to work correctly.
